### PR TITLE
fix fish, rats, cannons, allow zooming. mostly fix mirrors. sorta fix launchers

### DIFF
--- a/data/goal_src/jak1/engine/common-obs/generic-obs.gc
+++ b/data/goal_src/jak1/engine/common-obs/generic-obs.gc
@@ -1917,7 +1917,7 @@
 
 (defstate launcher-active (launcher)
   :event (behavior ((arg0 process) (arg1 int) (arg2 symbol) (arg3 event-message-block))
-    (when (or (= arg2 'touch) (= arg2 'attack))
+    (when (= arg2 'attack)
       (set! (-> self state-time) (-> *display* base-frame-counter))
       (send-event arg0 'launch (-> self spring-height) (-> self camera) (-> self dest) (-> self seek-time))
       )

--- a/data/goal_src/jak1/engine/game/main.gc
+++ b/data/goal_src/jak1/engine/game/main.gc
@@ -105,8 +105,14 @@
 (set! flutflut? (aif *target* (case (-> it next-state name) (
                                       ('target-flut-air-attack
                                        'target-flut-air-attack-hit-ground
+                                       'target-flut-clone-anim
+                                       'target-flut-death
                                        'target-flut-double-jump
                                        'target-flut-falling
+                                       'target-flut-get-off
+                                       'target-flut-get-off-hit-ground
+                                       'target-flut-get-off-jump
+                                       'target-flut-get-on
                                        'target-flut-grab
                                        'target-flut-hit
                                        'target-flut-hit-ground
@@ -114,7 +120,15 @@
                                        'target-flut-running-attack
                                        'target-flut-stance
                                        'target-flut-start
-                                       'target-flut-walk) #t))))
+                                       'target-flut-walk
+                                       ;; not flutflut, but we don't need to force flutflut in these cases
+                                       'target-periscope
+                                       'target-falling
+                                       'target-clone-anim
+                                       'target-play-anim
+                                       'target-billy-game
+                                       'target-look-around
+                                       'target-fishing) #t))))
 
 (if (not flutflut?)  (send-event *target* 'change-mode 'flut #f))
 

--- a/data/goal_src/jak1/engine/game/main.gc
+++ b/data/goal_src/jak1/engine/game/main.gc
@@ -128,9 +128,15 @@
                                        'target-play-anim
                                        'target-billy-game
                                        'target-look-around
-                                       'target-fishing) #t))))
+                                       'target-fishing
+                                       ;; launcher crap
+                                       'target-launch
+                                       'target-high-jump
+                                       'target-duck-high-jump
+                                       'target-duck-high-jump-jump
+                                       'target-hit-ground) #t))))
 
-(if (not flutflut?)  (send-event *target* 'change-mode 'flut #f))
+(if (not flutflut?) (send-event *target* 'change-mode 'flut #f))
 
   "Are we in a movie?"
   (logtest? (-> *kernel-context* prevent-from-run) (process-mask movie))

--- a/data/goal_src/jak1/levels/flut_common/target-flut.gc
+++ b/data/goal_src/jak1/levels/flut_common/target-flut.gc
@@ -69,7 +69,7 @@
                            :alignv 1.0
                            :slope-up-traction 1.0
                            :align-speed 1.0
-                           :flags (surface-flags no-turn-around)
+                           :flags (surface-flags allow-look-around no-turn-around)
                            )
         )
 
@@ -336,6 +336,9 @@
          (case (-> arg3 param 0)
            (('grab)
             (go target-flut-grab)
+            )
+           (else  ;; handles changing to look-around, fish game, rats game, periscopes, etc
+            (target-standard-event-handler arg0 arg1 arg2 arg3)
             )
            )
          )

--- a/data/goal_src/jak1/levels/flut_common/target-flut.gc
+++ b/data/goal_src/jak1/levels/flut_common/target-flut.gc
@@ -342,6 +342,16 @@
             )
            )
          )
+        (('launch)
+         (mem-copy! (&-> (-> self control) unknown-pointer00) (the-as pointer arg3) 72)
+         (let ((a0-9 (-> self control unknown-dword60))
+                (a1-5 (-> self control unknown-dword61))
+                (a2-5 (-> self control unknown-vector102))
+                )
+            (set! (-> a2-5 quad) (-> (the-as vector (-> self control unknown-dword62)) quad))
+            (go target-launch (the-as float a0-9) (the-as symbol a1-5) a2-5 (-> self control unknown-dword63))
+            )
+         )
         (('clone-anim)
          (go target-flut-clone-anim (process->handle (the-as process (-> arg3 param 0))))
          )
@@ -793,6 +803,48 @@
       )
     )
   :enter (behavior ((arg0 float) (arg1 float))
+    (when (= (-> self control unknown-symbol40) 'launch)
+      (level-hint-spawn
+        (game-text-id sidekick-launcher1)
+        "sksp009d"
+        (the-as entity #f)
+        *entity-pool*
+        (game-task none)
+        )
+      (level-hint-spawn
+        (game-text-id sidekick-launcher2)
+        "sksp009e"
+        (the-as entity #f)
+        *entity-pool*
+        (game-task none)
+        )
+      (case (-> (level-get-target-inside *level*) name)
+        (('citadel)
+         (level-hint-spawn
+           (game-text-id citadel-launcher2)
+           "sksp0393"
+           (the-as entity #f)
+           *entity-pool*
+           (game-task none)
+           )
+         (level-hint-spawn
+           (game-text-id citadel-launcher)
+           "sksp0388"
+           (the-as entity #f)
+           *entity-pool*
+           (game-task none)
+           )
+         )
+        )
+      enter-state
+      (let ((a0-9 (-> self control unknown-dword60))
+            (a1-5 (-> self control unknown-dword61))
+            (a2-5 (-> self control unknown-vector102))
+            )
+        (set! (-> a2-5 quad) (-> (the-as vector (-> self control unknown-dword62)) quad))
+        (go target-launch (the-as float a0-9) (the-as symbol a1-5) a2-5 (-> self control unknown-dword63))
+        )
+      )
     (set! (-> self state-time) (-> *display* base-frame-counter))
     (sound-play "jump" :pitch -0.5)
     (init-var-jump arg0 arg1 (the-as vector #t) (the-as vector #t) (-> self control transv))
@@ -924,6 +976,16 @@
 (defstate target-flut-double-jump (target)
   :event (-> target-flut-jump event)
   :enter (behavior ((arg0 float) (arg1 float))
+    (when (= (-> self control unknown-symbol40) 'launch)
+      enter-state
+      (let ((a0-3 (-> self control unknown-dword60))
+            (a1-1 (-> self control unknown-dword61))
+            (a2-0 (-> self control unknown-vector102))
+            )
+        (set! (-> a2-0 quad) (-> (the-as vector (-> self control unknown-dword62)) quad))
+        (go target-launch (the-as float a0-3) (the-as symbol a1-1) a2-0 (-> self control unknown-dword63))
+        )
+      )
     (set! (-> self state-time) (-> *display* base-frame-counter))
     (init-var-jump arg0 arg1 (the-as vector #t) (the-as vector #t) (-> self control transv))
     (set! (-> self control dynam gravity-max) 40960.0)


### PR DESCRIPTION
#7 #8 #11

weird warp happens after each mirrors cutscene

had to add a few extra states to the list for launchers to work, it potentially gives people more ways to remain off of flutflut but idk how else to get launchers working without doing something more customized 